### PR TITLE
feat(php-sdk): add php-sdk-lint.yml shareable lint workflow

### DIFF
--- a/.github/workflows/php-sdk-lint.yml
+++ b/.github/workflows/php-sdk-lint.yml
@@ -1,0 +1,120 @@
+name: Lint & Security
+on:
+  workflow_call:
+
+jobs:
+  composer-audit:
+    name: "Audit: PHP Dependencies"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Audit PHP dependencies
+        run: composer audit --no-dev
+
+  trufflehog:
+    name: "Audit: Secret Scanning"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: trufflesecurity/trufflehog@main
+        with:
+          extra_args: --only-verified
+
+  actionlint:
+    name: "Lint: GitHub Actions"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: reviewdog/action-actionlint@v1
+        with:
+          reporter: github-pr-review
+
+  hadolint:
+    name: "Lint: Dockerfile"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: hadolint/hadolint-action@v3.3.0
+        with:
+          dockerfile: .devcontainer/Dockerfile
+
+  shellcheck:
+    name: "Lint: ShellCheck"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: ShellCheck
+        run: composer shellcheck
+
+  phpcs:
+    name: "Lint: PHP CodeSniffer"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: PHP CodeSniffer
+        run: composer phpcs
+
+  phpstan:
+    name: "Lint: PHPStan"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: PHPStan
+        run: composer phpstan
+
+  psalm:
+    name: "Lint: PHP Psalm"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - name: Psalm
+        run: composer psalm


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/php-sdk-lint.yml` as a reusable (`workflow_call`) lint workflow for PHP SDK repos
- Covers all jobs from the local `lint.yml`: composer audit, secret scanning, GitHub Actions lint, Dockerfile lint, ShellCheck, PHPCS, PHPStan, and Psalm
- Per-job `permissions` declared; `actionlint` job gets `pull-requests: write` for the `github-pr-review` reporter

## Test plan

- [ ] PR in `rtldev-middleware-php-sdk` calls this workflow and all jobs pass
- [ ] `workflow_run` chain (Lint & Security → tests) continues to work correctly

Resolves: [RSRMID-2816](https://centralnic.atlassian.net/browse/RSRMID-2816)

🤖 Generated with [Claude Code](https://claude.com/claude-code)