### PR TITLE
ci(php-sdk): drop ref input from php-sdk-test.yml

### DIFF
--- a/.github/workflows/php-sdk-test.yml
+++ b/.github/workflows/php-sdk-test.yml
@@ -1,12 +1,6 @@
 name: Coverage & Tests
 on:
   workflow_call:
-    inputs:
-      ref:
-        description: "Commit SHA to check out (pass github.event.workflow_run.head_sha when triggered via workflow_run)"
-        type: string
-        required: false
-        default: ""
 
 jobs:
   test_matrix:
@@ -21,7 +15,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ inputs.ref }}
           fetch-depth: 0
           persist-credentials: false
       - name: Install PHP ${{ matrix.php-version }}


### PR DESCRIPTION
## Summary

- Removes the `ref` input (and its `workflow_call` declaration) from `php-sdk-test.yml`
- The `ref` input was only needed when `test.yml` was triggered via `workflow_run` and had to explicitly check out the PR's head SHA
- With the PHP SDK repos switching `test.yml` to a `pull_request` trigger (running tests in parallel with lint), the checkout default ref is already correct — no `ref` input needed
- Also removes `ref: ${{ inputs.ref }}` from the `actions/checkout` step

## Context

Part of RSRMID-2816: after moving `lint.yml` to a thin caller of `php-sdk-lint.yml`, the `workflow_run` chain (`Lint & Security` → tests) broke because any lint failure caused the `tests` job to be skipped and `ci-success` to fail. Switching PHP SDK repos to `pull_request` trigger fixes this and simplifies the setup.

## Related

- Shareable workflows PR #86 (`php-sdk-lint.yml`)
- PHP SDK PR #181 (switches `test.yml` to `pull_request` trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)