### PR TITLE
ci(whmcs): add monthly WHMCS PHP version check workflow

### DIFF
--- a/.github/workflows/whmcs-php-check.yml
+++ b/.github/workflows/whmcs-php-check.yml
@@ -1,0 +1,94 @@
+name: WHMCS PHP Version Check
+
+on:
+  workflow_call:
+    inputs:
+      pinned-php-version:
+        description: "PHP version currently pinned in the project (e.g. 8.3)"
+        type: string
+        required: false
+        default: "8.3"
+
+jobs:
+  check:
+    name: "\U0001F50D WHMCS PHP compatibility"
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Fetch WHMCS version data
+        id: versions
+        run: |
+          RESPONSE=$(curl -fs --max-time 15 -X POST https://download.whmcs.com/assets/scripts/get-downloads.php)
+          if [ -z "$RESPONSE" ]; then
+            echo "::error::Failed to fetch WHMCS version data from download.whmcs.com"
+            exit 1
+          fi
+
+          GA_MAJOR=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['latestVersionMajor'])")
+          LTS_VERSION=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d['ltsReleases'][0]['version'])")
+          LTS_MAJOR=$(echo "$LTS_VERSION" | grep -oE '^[0-9]+\.[0-9]+')
+
+          if [ -z "$GA_MAJOR" ] || [ -z "$LTS_MAJOR" ]; then
+            echo "::error::Could not parse GA or LTS major version from WHMCS API response — manual check required"
+            exit 1
+          fi
+
+          echo "ga_major=$GA_MAJOR" >> "$GITHUB_OUTPUT"
+          echo "lts_major=$LTS_MAJOR" >> "$GITHUB_OUTPUT"
+          echo "Detected: GA=$GA_MAJOR, LTS=$LTS_MAJOR"
+
+      - name: Fetch PHP version ranges from WHMCS docs
+        id: php_versions
+        run: |
+          GA_SLUG=$(echo "${{ steps.versions.outputs.ga_major }}" | tr '.' '-')
+          LTS_SLUG=$(echo "${{ steps.versions.outputs.lts_major }}" | tr '.' '-')
+
+          GA_PHPVERS=$(curl -fs --max-time 15 "https://docs.whmcs.com/${GA_SLUG}/installation-guide/system-requirements/" \
+            | grep -oE 'PHP [0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+' | sort -uV)
+          LTS_PHPVERS=$(curl -fs --max-time 15 "https://docs.whmcs.com/${LTS_SLUG}/installation-guide/system-requirements/" \
+            | grep -oE 'PHP [0-9]+\.[0-9]+' | grep -oE '[0-9]+\.[0-9]+' | sort -uV)
+
+          if [ -z "$GA_PHPVERS" ]; then
+            echo "::error::Could not extract PHP versions from WHMCS ${{ steps.versions.outputs.ga_major }} docs — manual check required (docs layout may have changed)"
+            exit 1
+          fi
+          if [ -z "$LTS_PHPVERS" ]; then
+            echo "::error::Could not extract PHP versions from WHMCS ${{ steps.versions.outputs.lts_major }} docs — manual check required (docs layout may have changed)"
+            exit 1
+          fi
+
+          GA_MIN=$(echo "$GA_PHPVERS" | head -1)
+          LTS_MAX=$(echo "$LTS_PHPVERS" | tail -1)
+
+          echo "ga_min_php=$GA_MIN" >> "$GITHUB_OUTPUT"
+          echo "lts_max_php=$LTS_MAX" >> "$GITHUB_OUTPUT"
+          echo "WHMCS GA ${{ steps.versions.outputs.ga_major }}: min supported PHP $GA_MIN"
+          echo "WHMCS LTS ${{ steps.versions.outputs.lts_major }}: max supported PHP $LTS_MAX"
+
+      - name: Compare against pinned version
+        run: |
+          PINNED="${{ inputs.pinned-php-version }}"
+          LTS_MAX="${{ steps.php_versions.outputs.lts_max_php }}"
+          GA_MIN="${{ steps.php_versions.outputs.ga_min_php }}"
+
+          echo "Pinned PHP:          $PINNED"
+          echo "WHMCS LTS max PHP:   $LTS_MAX  (WHMCS ${{ steps.versions.outputs.lts_major }})"
+          echo "WHMCS GA min PHP:    $GA_MIN   (WHMCS ${{ steps.versions.outputs.ga_major }})"
+
+          version_gt() {
+            [ "$(printf '%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ] && [ "$1" != "$2" ]
+          }
+
+          FAIL=0
+          if version_gt "$LTS_MAX" "$PINNED"; then
+            echo "::error::WHMCS LTS (${{ steps.versions.outputs.lts_major }}) now supports up to PHP $LTS_MAX — the pinned version $PINNED may need to be raised."
+            FAIL=1
+          fi
+          if version_gt "$GA_MIN" "$PINNED"; then
+            echo "::error::WHMCS GA (${{ steps.versions.outputs.ga_major }}) now requires PHP $GA_MIN minimum — the pinned version $PINNED is below the new floor."
+            FAIL=1
+          fi
+
+          [ "$FAIL" -eq 0 ] || exit 1
+          echo "PHP $PINNED is still correct — no action required."


### PR DESCRIPTION
## Summary

Adds a reusable (`workflow_call`) workflow that verifies whether the PHP version pinned in a consuming project is still consistent with WHMCS's supported PHP range.

Consumed by `rtldev-middleware-php-sdk` (see its `.github/workflows/whmcs-php-check.yml` caller, PR #201), which pins PHP 8.3 because the SDK runs inside WHMCS environments.

## How it works

1. POSTs to `https://download.whmcs.com/assets/scripts/get-downloads.php` — returns clean JSON with the current GA (`latestVersionMajor`) and LTS (`ltsReleases`) major versions (no auth required).
2. Fetches the system-requirements docs page for each version and greps for `PHP X.Y` mentions.
3. **Fails** if the LTS max PHP or GA min PHP rises above the pinned version, or if the docs can't be parsed (manual check required).
4. **Succeeds** silently if the pinned version is still correct.

## Inputs

- `pinned-php-version` (string, default `8.3`) — the PHP version the consumer pins.

Relates to: https://centralnic.atlassian.net/browse/RSRMID-2826