### PR TITLE
ci(php-sdk-release): move docs generation into semantic-release

### DIFF
--- a/.github/workflows/php-sdk-release.yml
+++ b/.github/workflows/php-sdk-release.yml
@@ -48,15 +48,10 @@ jobs:
         with:
           php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
           coverage: xdebug
-      - name: PHP Class Documentation
+      - name: Install PHP Dependencies
         run: |
-          composer update --no-dev
-          composer run-script docs
-      - name: Generate UML Diagram for PHP Classes
-        run: | 
           echo "$HOME/.composer/vendor/bin" >> "$GITHUB_PATH"
           composer install
-          composer run-script generate-uml          
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}


### PR DESCRIPTION
## Summary

Removes the unconditional **"PHP Class Documentation"** and **"Generate UML Diagram"** steps from the PHP SDK release job. Documentation generation now happens inside the semantic-release lifecycle (`@semantic-release/exec` `prepareCmd`) in the consuming repo, and publishing to `gh-pages` happens in `successCmd` — so docs are built and published **only when a release is actually cut**, not on every push to master.

A single `composer install` step is kept so the release job still provides the dependencies `prepareCmd` needs; the Java / Graphviz / PHP setup is retained because the doc + UML generation now runs within the release step.

### Side effect (improvement)
The old flow ran `composer update --no-dev`, which could mutate `composer.lock` and commit it as part of the release. The new `composer install` no longer bumps dependencies during release — dependency updates stay confined to Dependabot/refresh PRs.

## Merge order
Depends on **rtldev-middleware-php-sdk#203**, which adds the docs `prepareCmd`/`successCmd` to `.releaserc.json`. **Merge #203 first** — otherwise a release here would generate no docs.

Relates to: https://centralnic.atlassian.net/browse/RSRMID-2827