### PR TITLE
feat(php-sdk-lint.yml): add opt-in prettier formatting job

### DIFF
--- a/.github/workflows/php-sdk-lint.yml
+++ b/.github/workflows/php-sdk-lint.yml
@@ -1,6 +1,16 @@
 name: Lint & Security
 on:
   workflow_call:
+    inputs:
+      prettier:
+        description: >-
+          Run the Prettier formatting check. Opt-in, because this is the only job
+          that needs the caller to bring a Node toolchain: it requires a committed
+          pnpm-lock.yaml, prettier in devDependencies, and a `prettier` composer
+          script. Left at false, the job is skipped and the caller is unaffected.
+        type: boolean
+        required: false
+        default: false
 
 jobs:
   composer-audit:
@@ -54,6 +64,46 @@ jobs:
       - uses: hadolint/hadolint-action@v3.3.0
         with:
           dockerfile: .devcontainer/Dockerfile
+
+  prettier:
+    name: "Lint: Prettier"
+    if: ${{ inputs.prettier }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ vars.RTLDEV_MW_CI_PHP_VERSION }}
+          coverage: none
+      # The prettier script itself only shells out to Node, so this install is not
+      # strictly required — it is here so the job keeps the identical shape to the
+      # six sibling jobs, and so a caller whose prettier script grows a PHP-side
+      # dependency does not have to change this workflow to get it.
+      - name: Install PHP dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+      - uses: pnpm/action-setup@v6
+        with:
+          version: latest
+      - name: Setup NodeJS ${{ vars.RTLDEV_MW_CI_NODE_VERSION }}
+        uses: actions/setup-node@v7
+        with:
+          node-version: ${{ vars.RTLDEV_MW_CI_NODE_VERSION }}
+          check-latest: true
+          cache: pnpm
+      # --frozen-lockfile so the run uses the prettier pinned in pnpm-lock.yaml.
+      # Load-bearing, not hygiene: prettier's output changes between minors, so a
+      # floating install produces failures that cannot be reproduced locally.
+      - name: Install NodeJS dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Report the Prettier version under test
+        run: pnpm exec prettier --version
+      # Deliberately `composer prettier` rather than a raw prettier call: the
+      # caller keeps ownership of the arguments and .prettierignore rules, and the
+      # job matches the one-composer-script shape of every other job here.
+      - name: Prettier
+        run: composer prettier
 
   shellcheck:
     name: "Lint: ShellCheck"


### PR DESCRIPTION
Adds a `prettier` job to `php-sdk-lint.yml`, gated behind a new `workflow_call` input that **defaults to `false`**. Resolves the CI half of [RSRMID-2929](https://centralnic.atlassian.net/browse/RSRMID-2929).

## Why

The PHP SDK enforced prettier only locally, and both paths are avoidable:

- **lint-staged** runs `prettier --write --ignore-unknown` at commit time. It rewrites rather than fails, and only touches *staged* files — so a file no commit happens to stage can drift permanently (`CONTRIBUTING.md` had drifted exactly that way).
- **`composer lint`** runs `prettier --check .` as of RSRMID-2923. Real enforcement, but opt-in: it only helps whoever runs it.

Neither covers a PR authored in the GitHub web editor, a bot PR, a `--no-verify` commit, or a contributor who never runs `composer lint`.

## Why the job is opt-in

This is the only job in this workflow that needs the **caller** to bring something: a committed `pnpm-lock.yaml`, prettier in `devDependencies`, and a `prettier` composer script. An unconditional job would break the first consumer without those — currently `rtldev-middleware-php-sdk` is the only repo in the org with a `.prettierrc`.

Auto-detecting a `.prettierrc` was considered and **rejected**: a job that silently self-skips reports green while checking nothing, so deleting the config would remove the gate with no signal. An explicit input makes the behaviour declared rather than inferred.

## Implementation notes

- **`composer prettier`, not a raw prettier call** — each consuming repo keeps ownership of the arguments and `.prettierignore` rules, and the job keeps the one-composer-script shape of every other job in this file.
- **`pnpm install --frozen-lockfile`** — load-bearing, not hygiene. Prettier's output changes between minor releases, so a floating install would produce a red CI that cannot be reproduced locally. The version is printed to a step of its own for exactly that comparison.
- **`composer install` is retained** even though the prettier script only shells out to Node, so the job keeps the identical shape to its six siblings and a caller whose script grows a PHP-side dependency needs no change here.
- **Actions pinned by floating major tag** (`@v7`, `@v6`), matching all 29 workflows in this repo and its daily Dependabot `github-actions` updates. The SHA-pinning rule in the php-sdk's `docs/agents/ci-release.md` is scoped to that repo — a lone SHA pin here would be inconsistent with the file it lives in.

## Verification

- `actionlint` clean.
- Consumers that do not opt in are unaffected: the job is skipped, and a skipped job does not fail the reusable call.
- Red/green proof of the check itself, run against the php-sdk tree at prettier 3.9.6 (the version in its `pnpm-lock.yaml`): a deliberately malformed `.md` makes `prettier --check .` exit 1 and **name the file**; without it the tree is clean.
- End-to-end CI proof lands with the consumer PR below, which is what actually exercises this job.

## Merge order

Merge this **first**. The companion PR — centralnicgroup-opensource/rtldev-middleware-php-sdk#305 — passes `prettier: true`, which is an unknown input until this is on `main`, so its run fails until then.