### PR TITLE
ci(php-sdk-release): provide the deploy key for the release push

### DIFF
--- a/.github/workflows/php-sdk-release.yml
+++ b/.github/workflows/php-sdk-release.yml
@@ -52,6 +52,36 @@ jobs:
         run: |
           echo "$HOME/.composer/vendor/bin" >> "$GITHUB_PATH"
           composer install
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
+      # GITHUB_TOKEN stays: @semantic-release/github creates the GitHub release with it,
+      # and the exec successCmd force-pushes gh-pages with it. Only the git push moved
+      # to SSH — and only because .releaserc.json pins repositoryUrl to the git@ form,
+      # without which get-git-auth-url.js expands the shortcut URL to HTTPS first and
+      # SSH is never attempted.
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}


### PR DESCRIPTION
Part of [RSRMID-2994](https://centralnic.atlassian.net/browse/RSRMID-2994) — php-sdk is the pilot.

## What

Writes `secrets.RTLDEV_MW_CI_SSH_KEY` to `~/.ssh/id_ed25519` before `semantic-release` runs, so the `@semantic-release/git` push to `master` goes over SSH with a deploy key instead of `RTLDEV_MW_CI_TOKEN`.

## Why

`RTLDEV_MW_CI_TOKEN` is a personal account PAT with admin over every repository in the organisation. Today it pushes the release commit past classic branch protection only because `enforce_admins` is `false` and its owner is an admin — an implicit bypass that rulesets do not have. That is why php-sdk (and eight others) currently carry `RULESET_ENABLED=false` and have *weaker* protection than before settings were centralised.

A deploy key reaches exactly one repository. With `DeployKey` as the ruleset's only bypass actor, the release push gets through and nothing else does.

## Notes for review

- The key is passed via `env`, not interpolated into the `run` body — `${{ }}` breaks on multi-line values and is an injection surface.
- The step **fails** on an empty secret. semantic-release silently falls back to HTTPS when SSH auth fails, so a missing secret would otherwise be discovered as a rejected push at the very end of the release, after the version was chosen and the tag written.
- `GITHUB_TOKEN` is unchanged — `@semantic-release/github` needs it for the GitHub release and `publish-docs.sh` for the `gh-pages` force-push. Only the git push moved.
- `gh-pages` needs no change: the ruleset targets `~DEFAULT_BRANCH` only, so unlike `devcontainer-features` this repository's second push is not affected.
- The SSH path is only reached because php-sdk's `.releaserc.json` pins `repositoryUrl` to the `git@` form. `lib/get-git-auth-url.js` expands shortcut URLs to HTTPS *before* trying SSH, and php-sdk's `package.json` carries a shortcut.

## Order

Merge **first**, and only after `RTLDEV_MW_CI_SSH_KEY` exists on php-sdk. Then the php-sdk `.releaserc.json` PR, then the workspace register PR followed by `org-settings.sh --apply php-sdk`.

Affects php-sdk only — this file is called by php-sdk alone, and only php-sdk carries the secret. The remaining eight repositories follow one at a time.

Note: `php-sdk-release.yml` line 45 has pre-existing trailing whitespace that prettier objects to. Left alone, so this diff stays to the change at hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
