### PR TITLE
ci(php-sdk-release): log the release push auth path for the pilot run

### DIFF
--- a/.github/workflows/php-sdk-release.yml
+++ b/.github/workflows/php-sdk-release.yml
@@ -87,4 +87,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}
           TEAMS_NOTIFICATION_URI: ${{ secrets.RTLDEV_MW_CI_NOTIFICATION_URI }}
           COMMIT_SHA: ${{ github.sha }}
+          # TEMPORARY — remove after the first release of RSRMID-2994 has been checked.
+          # Logs which auth path get-git-auth-url.js chose: "SSH key auth successful."
+          # means the deploy key was used, "SSH key auth failed, falling back to https."
+          # means it was not. Scoped to that one namespace, so nothing else is verbose.
+          DEBUG: semantic-release:get-git-auth-url
         run: pnpm exec semantic-release


### PR DESCRIPTION
Part of [RSRMID-2994](https://centralnic.atlassian.net/browse/RSRMID-2994) — P8, for the php-sdk pilot run. **Temporary; remove after the first release is checked.**

## What

One env line on the `Release` step:

```yaml
DEBUG: semantic-release:get-git-auth-url
```

The log then says either `SSH key auth successful.` — the deploy key was used — or `SSH key auth failed, falling back to https.` Scoped to that one namespace, so the rest of semantic-release stays quiet.

## Why it is still worth having, and why it is nearly redundant

Measured against the now-live ruleset before opening this: **GitHub does not evaluate rulesets on `git push --dry-run`.** A real new commit object was dry-run-pushed to `refs/heads/master` twice — once over SSH with the deploy key, once over HTTPS with an admin PAT that is *not* a bypass actor — and both were accepted.

That settles the open question in the ticket, in the favourable direction: `verifyAuth` cannot be tricked into a false fallback by the ruleset, because the dry-run it runs is never rejected. It tests authentication, not authorisation.

`GET /repos/.../rules/branches/master` confirms the *real* push is still gated — all five rules apply to that same admin PAT actor, `pull_request` included. So an HTTPS fallback push would be rejected and the release would fail loudly, which means a release that completes is already strong evidence the deploy key was used.

This line turns that inference into a direct statement in the log. Worth one release run.

## The one cost

That namespace logs `repositoryUrl`, which on the fallback path carries the token. Actions secret-masking is what keeps it out of a public repository's log, so this should not stay longer than the one run it exists for.

## Removal

After the first release: drop these five lines (the marker comment names the condition), then check that the tag points at the `chore(release)` commit and that `VERSION` in `src/AbstractClient.php` carries the new version. Then P9 — remove php-sdk's classic branch protection on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
