### PR TITLE
ci(php-sdk-release): drop the temporary release auth debug flag

### DIFF
--- a/.github/workflows/php-sdk-release.yml
+++ b/.github/workflows/php-sdk-release.yml
@@ -87,9 +87,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}
           TEAMS_NOTIFICATION_URI: ${{ secrets.RTLDEV_MW_CI_NOTIFICATION_URI }}
           COMMIT_SHA: ${{ github.sha }}
-          # TEMPORARY — remove after the first release of RSRMID-2994 has been checked.
-          # Logs which auth path get-git-auth-url.js chose: "SSH key auth successful."
-          # means the deploy key was used, "SSH key auth failed, falling back to https."
-          # means it was not. Scoped to that one namespace, so nothing else is verbose.
-          DEBUG: semantic-release:get-git-auth-url
         run: pnpm exec semantic-release


### PR DESCRIPTION
Reverts centralnicgroup-opensource/rtldev-middleware-shareable-workflows#105 now that it has done its job. [RSRMID-2994](https://centralnic.atlassian.net/browse/RSRMID-2994) P8.

## The evidence it was added for

php-sdk `33.0.3`, [run 32981253299](https://github.com/centralnicgroup-opensource/rtldev-middleware-php-sdk/actions/runs/32981253299):

```
semantic-release:get-git-auth-url Verifying ssh auth by attempting to push to
  git@github.com:centralnicgroup-opensource/rtldev-middleware-php-sdk.git
semantic-release:get-git-auth-url SSH key auth successful.
```

Not the fallback line, and the URL is the `git@` form — so the deploy key carried the push and `.releaserc.json`'s `repositoryUrl` override is doing real work. Tag `v33.0.3` points at the `chore(release)` commit and `VERSION` in `src/AbstractClient.php` reads `33.0.3`.

## Why it does not stay

That namespace logs `repositoryUrl`, which on the fallback path carries the token. Actions secret-masking is the only thing between that and a public repository's log, and that is not a guarantee worth leaning on past the one run it was needed for.

The file is now byte-identical to `c87514b`, its state before the flag was added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)