### PR TITLE
ci(workflows): also run on reopened pull requests

### DIFF
--- a/.github/workflows/self-test-auto-merge-dependabot.yml
+++ b/.github/workflows/self-test-auto-merge-dependabot.yml
@@ -4,6 +4,7 @@ on:
     types:
       - opened
       - synchronize
+      - reopened
 
 jobs:
   tests:


### PR DESCRIPTION
Jira: https://centralnic.atlassian.net/browse/RSRMID-2998

Adds `reopened` to the `pull_request` trigger's `types:` list.

## Why

An explicit `types:` list **replaces** GitHub's default
`opened, synchronize, reopened` — it does not extend it. These workflows listed
only `opened` and `synchronize`, so reopening a pull request created no run at
all.

Where such a workflow publishes a **required** status check, that leaves a
reopened pull request permanently blocked. The check is *absent* rather than
failed, so there is nothing to re-run, and the only way out is pushing another
commit to the head branch.

## Why now, and why this is not urgent

`REQUIRED_CHECKS` is currently set for only four repositories (php-sdk,
template, devcontainer-features, workspace) and none of them is affected —
php-sdk already lists `reopened`. So the gap is latent today.

It goes live the moment RSRMID-2991 fills `REQUIRED_CHECKS` for the remaining
repositories: these files become merge-blocking, and the failure surfaces as a
stuck pull request rather than a red check. Fixing it beforehand is a one-line
edit; afterwards it is a debugging session.

## Scope

Option A of two — add the type explicitly, rather than deleting `types:` and
inheriting the default. Explicit keeps the file auditable by grep and does not
leave a merge gate defined by a GitHub default that could change. Applied
identically across all ten affected files so an absent `types:` block stays
unambiguous.

Found by enumerating every workflow file in the registered repositories plus
`shareable-workflows` against their default branches: 10 correct, 54 with no
`pull_request` trigger, 10 affected. `whmcs` was not readable and is unverified.

No formatting changes are included. Four of these files already fail a
`prettier` check on their default branch, but prettier is neither a declared
dependency nor gated in CI there — reformatting would bury a one-line fix in
unrelated churn.