### PR TITLE
ci(release): push the release commit over SSH with a deploy key

### DIFF
--- a/.github/workflows/go-sdk-release.yml
+++ b/.github/workflows/go-sdk-release.yml
@@ -35,6 +35,31 @@ jobs:
           cache: pnpm
       - name: Install NodeJS Dependencies
         run: pnpm i --frozen-lockfile
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}

--- a/.github/workflows/idna-uts46-release.yml
+++ b/.github/workflows/idna-uts46-release.yml
@@ -32,6 +32,31 @@ jobs:
         run: |
           npm i -g pnpm
           pnpm i --frozen-lockfile
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}

--- a/.github/workflows/java-sdk-release.yml
+++ b/.github/workflows/java-sdk-release.yml
@@ -52,6 +52,31 @@ jobs:
           rm -rf target
           unzip -qq -o target.zip
           rm target.zip
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}

--- a/.github/workflows/middleware-blesta-release.yml
+++ b/.github/workflows/middleware-blesta-release.yml
@@ -39,6 +39,31 @@ jobs:
           cache: pnpm
       - name: Install NodeJS Dependencies
         run: pnpm i --frozen-lockfile
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}

--- a/.github/workflows/node-sdk-release.yml
+++ b/.github/workflows/node-sdk-release.yml
@@ -42,6 +42,31 @@ jobs:
         # summary instead of silently swallowing it (as `|| true` would).
         continue-on-error: true
         run: pnpm run documentation
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}

--- a/.github/workflows/php-idna-translator-release.yml
+++ b/.github/workflows/php-idna-translator-release.yml
@@ -52,6 +52,31 @@ jobs:
           pattern: coverage-folder-*
           merge-multiple: true
           path: reports
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.RTLDEV_MW_CI_TOKEN }}

--- a/.github/workflows/python-sdk-release.yml
+++ b/.github/workflows/python-sdk-release.yml
@@ -51,6 +51,31 @@ jobs:
           pattern: coverage-folder-*
           merge-multiple: true
           path: htmlcov
+      # @semantic-release/git pushes the release commit straight to the default branch,
+      # which no pull request can carry — it happens after the version is decided. The
+      # ruleset therefore names DeployKey as its only bypass actor, and this is the key:
+      # per-repository, write-enabled, so a leak costs one repository rather than every
+      # repository a personal access token can reach.
+      #
+      # The key goes through env, not through ${{ }} interpolated into the script body:
+      # a multi-line value breaks there, and the body is a shell injection surface.
+      #
+      # Fails on an empty secret rather than letting it through. semantic-release falls
+      # back to HTTPS when SSH auth fails and does not re-verify, so an unset secret
+      # would surface as a rejected push at the very end of the release, after the
+      # version has already been chosen and the tag written.
+      - name: Configure SSH for the release push
+        env:
+          SSH_KEY: ${{ secrets.RTLDEV_MW_CI_SSH_KEY }}
+        run: |
+          if [ -z "$SSH_KEY" ]; then
+            echo "::error::RTLDEV_MW_CI_SSH_KEY is not set — the release push has no identity"
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -t ed25519 github.com >> ~/.ssh/known_hosts
       - name: Release
         env:
           TWINE_LIVE_USERNAME: ${{ secrets.TWINE_LIVE_USERNAME }}


### PR DESCRIPTION
Jira: https://centralnic.atlassian.net/browse/RSRMID-2994

Adds the SSH setup step to the seven release workflows that did not have it yet, so all eight in `.github/workflows/` are now identical on this point. The block is byte-identical to the one `php-sdk-release.yml` has carried since RSRMID-2994's pilot.

| workflow | consumer |
| --- | --- |
| `php-idna-translator-release.yml` | php-idna-translator |
| `node-sdk-release.yml` | node-sdk |
| `java-sdk-release.yml` | java-sdk |
| `python-sdk-release.yml` | python-sdk |
| `go-sdk-release.yml` | go-sdk |
| `middleware-blesta-release.yml` | blesta |
| `idna-uts46-release.yml` | idna-uts46 |

### Why

`@semantic-release/git` pushes the release commit straight to the default branch, after the version has been decided, so no pull request can carry it. The default-branch ruleset therefore names `DeployKey` as its only bypass actor. Each of the seven repositories now has exactly one write-enabled deploy key titled `semantic-release`, whose private half is the repository secret `RTLDEV_MW_CI_SSH_KEY`.

A deploy key reaches one repository. The alternatives all reached further — a personal access token, a machine user's account key, and `secrets.GITHUB_TOKEN` with a bypass on the Actions integration would each hand the bypass to far more than the release push.

### This alone does not switch anything

The step only puts a key on disk. Two further changes per repository make it the push identity, and they land alongside this one:

- `repositoryUrl` in `.releaserc.json` pinned to the `git@` form — without it `get-git-auth-url.js` expands the shortcut URL to HTTPS and SSH is never attempted.
- the default-branch ruleset enabled with the `DeployKey::always` bypass, and classic branch protection removed in the same step. Classic protection requires a pull request and exempts only admins, so it would reject a deploy key where it accepts today's admin PAT.

`GITHUB_TOKEN` stays in the `Release` step: `@semantic-release/github` still needs it to create the GitHub release. Only the git push moves.